### PR TITLE
Add more sections to the manifest

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,5 @@
 #include "main_common.h"
 
-
-
 static void parse_cmd_args(Options& opts, std::span<char const*> args) {
     opts.docker_base_image = base_image(opts.os_release);
 
@@ -75,7 +73,7 @@ static int do_main(std::span<char const*> args) {
         exit(1);
     }
 
-    return  run_from_options(options);
+    return run_from_options(options);
 }
 
 int main(int argc, char* argv[]) {

--- a/src/main_common.h
+++ b/src/main_common.h
@@ -68,9 +68,8 @@ static void register_error_handler(Tracer& tracer) {
     return STR(os_release.distribution << ':' << r);
 }
 
-
 static int run_from_options(Options& options) {
-    
+
     Tracer tracer{options};
 
     // Interrupt signals generated in the terminal are delivered to the
@@ -92,5 +91,3 @@ static int run_from_options(Options& options) {
 
     return EXIT_SUCCESS;
 }
-
-

--- a/src/manifest.h
+++ b/src/manifest.h
@@ -19,6 +19,8 @@ enum class FileStatus {
     IgnoreDirectory
 };
 
+enum class PackageStatus { Ignore, Install };
+
 namespace std {
 inline std::ostream& operator<<(std::ostream& os, FileStatus status) {
     switch (status) {
@@ -44,6 +46,17 @@ inline std::ostream& operator<<(std::ostream& os, FileStatus status) {
     return os;
 }
 
+inline std::ostream& operator<<(std::ostream& os, PackageStatus status) {
+    switch (status) {
+    case PackageStatus::Ignore:
+        os << "Ignore";
+        break;
+    case PackageStatus::Install:
+        os << "Install";
+        break;
+    }
+    return os;
+}
 }; // namespace std
 
 struct Manifest {

--- a/src/manifest_section.h
+++ b/src/manifest_section.h
@@ -192,7 +192,11 @@ inline bool RPackagesManifestSection::save(std::ostream& stream,
     with_prefixed_ostream(stream, ManifestFormat::prefixed_comment(), [&] {
         stream << "The following R packages have been resolved.\n"
                << "# - ignores the package.\n"
-               << "I - marks the package to be installed in the image.\n";
+               << "cran packageName version - marks the package from CRAN at "
+                  "version"
+                  "to be installed in the image.\n"
+               << "github org/name@ref - marks the package from GitHub to be "
+                  "installed in the image.\n";
     });
 
     std::vector<RPackage const*> sorted_packages;
@@ -239,13 +243,13 @@ inline bool RPackagesManifestSection::save(std::ostream& stream,
     for (auto const* pkg : manifest.r_packages) {
         if (std::holds_alternative<RPackage::GitHub>(pkg->repository)) {
             auto const& gh = std::get<RPackage::GitHub>(pkg->repository);
-            stream << "I" << " github " << gh.org << '/' << gh.name << '@'
-                   << gh.ref << '\n';
+            stream << "github " << gh.org << '/' << gh.name << '@' << gh.ref
+                   << '\n';
         } else if (std::holds_alternative<RPackage::CRAN>(pkg->repository)) {
-            stream << "I" << " cran " << pkg->name << '\n';
+            stream << "cran " << pkg->name << " " << pkg->version << '\n';
         } else {
             LOG(WARN) << "Unknown R package repository type for package "
-                      << pkg->name;
+                      << pkg->name << " version" << pkg->version;
         }
     }
 

--- a/src/manifest_section.h
+++ b/src/manifest_section.h
@@ -3,6 +3,7 @@
 
 #include "manifest.h"
 #include "manifest_format.h"
+#include "rpkg_database.h"
 #include <string>
 
 class ManifestSection {
@@ -97,6 +98,154 @@ inline bool CopyFilesManifestSection::save(std::ostream& stream,
         default:
             stream << ManifestFormat::comment() << ' ' << path.string() << ' '
                    << ManifestFormat::comment() << ' ' << status << '\n';
+        }
+    }
+
+    return true;
+}
+
+class RPackagesManifestSection : public ManifestSection {
+  public:
+    RPackagesManifestSection() : ManifestSection("r-packages") {}
+
+    void load(std::istream& stream, Manifest& manifest) override;
+    bool save(std::ostream& stream, Manifest const& manifest) override;
+};
+
+inline void
+RPackagesManifestSection::load([[maybe_unused]] std::istream& stream,
+                               [[maybe_unused]] Manifest& manifest) {
+    std::string line;
+
+    // TODO: just filter out the packages we want to ignore here
+    // Otherwise, we would need to save more information in the
+    // Manifest to be ableto reconstruct a RPackage
+
+    /*
+    while (std::getline(stream, line)) {
+        if (line.empty() || line.starts_with(ManifestFormat::comment())) {
+            continue;
+        }
+
+        PackageStatus status{};
+
+        if (line.starts_with("I")) {
+            status = PackageStatus::Install;
+        } else {
+            LOG(WARN) << "Invalid manifest line: " << line;
+            continue;
+        }
+
+        auto parts = string_split(line, ' '); // TODO: make more robust to
+    various whitespaces
+        //manifest.r_packages.insert(pkg);
+        if (parts.size() < 3) {
+            LOG(WARN) << "Invalid R package line: " << line;
+            continue;
+        }
+        std::string repo = string_tolowercase(string_trim(parts[1]));
+        std::string name = string_trim(parts[2]);
+        if(name.empty()) {
+            LOG(WARN) << "Invalid R package name or origin: " << line;
+            continue;
+        }
+        if (repo == "cran") {
+            manifest.r_packages.insert(RPackage::CRAN);
+        } else if (repo == "github") {
+            // parse the name. It is as follows: org/name@ref
+            auto end_org = name.find('/');
+            if (end_org == std::string::npos) {
+                LOG(WARN) << "Invalid or missing GitHub repository organisation:
+    " << name; continue;
+            }
+            std::string org = name.substr(0, end_org);
+            std::string rest = name.substr(end_org);
+            auto end_name = rest.find('@');
+            std::string repo_name;
+            std::string ref;
+            if (end_name == std::string::npos) {
+                repo_name = rest;
+                ref = "HEAD"; // default to HEAD if no ref is provided
+            } else {
+                repo_name = rest.substr(0, end_name);
+                ref = rest.substr(end_name + 1);
+            }
+            if (org.empty() || repo_name.empty()) {
+                LOG(WARN) << "Invalid GitHub repository org or name: " << name;
+                continue;
+            }
+            auto gh = RPackage::GitHub{org, repo_name, ref};
+            manifest.r_packages.insert(gh);
+        } else {
+            LOG(WARN) << "Unknown R package repository type: " << repo;
+        }
+    }
+    */
+}
+
+inline bool RPackagesManifestSection::save(std::ostream& stream,
+                                           Manifest const& manifest) {
+    if (manifest.r_packages.empty()) {
+        return false;
+    }
+
+    with_prefixed_ostream(stream, ManifestFormat::prefixed_comment(), [&] {
+        stream << "The following R packages have been resolved.\n"
+               << "# - ignores the package.\n"
+               << "I - marks the package to be installed in the image.\n";
+    });
+
+    std::vector<RPackage const*> sorted_packages;
+    sorted_packages.reserve(manifest.r_packages.size());
+    for (auto const& p : manifest.r_packages) {
+        sorted_packages.emplace_back(p);
+    }
+
+    // TODO: rather add a operator< for RPackage (using std::tie)
+    std::sort(
+        sorted_packages.begin(), sorted_packages.end(),
+        [](RPackage const* lhs, RPackage const* rhs) {
+            std::string left;
+            std::string right;
+            if (std::holds_alternative<RPackage::GitHub>(lhs->repository)) {
+                left = std::get<RPackage::GitHub>(lhs->repository).org + '/' +
+                       std::get<RPackage::GitHub>(lhs->repository).name + '@' +
+                       std::get<RPackage::GitHub>(lhs->repository).ref;
+            } else if (std::holds_alternative<RPackage::CRAN>(
+                           lhs->repository)) {
+                left = lhs->name;
+            } else {
+                LOG(WARN) << "Unknown R package repository type for package "
+                          << lhs->name;
+                return false; // do not sort unknown types
+            }
+
+            if (std::holds_alternative<RPackage::GitHub>(rhs->repository)) {
+                right = std::get<RPackage::GitHub>(rhs->repository).org + '/' +
+                        std::get<RPackage::GitHub>(rhs->repository).name + '@' +
+                        std::get<RPackage::GitHub>(rhs->repository).ref;
+            } else if (std::holds_alternative<RPackage::CRAN>(
+                           rhs->repository)) {
+                right = rhs->name;
+            } else {
+                LOG(WARN) << "Unknown R package repository type for package "
+                          << rhs->name;
+                return false; // do not sort unknown types
+            }
+
+            return left < right;
+        });
+
+    for (auto const* pkg : manifest.r_packages) {
+        if (std::holds_alternative<RPackage::GitHub>(pkg->repository)) {
+            auto const& gh = std::get<RPackage::GitHub>(pkg->repository);
+            stream << "I" << " github " << gh.org << '/' << gh.name << '@'
+                   << gh.ref << '\n';
+        } else if (std::holds_alternative<RPackage::CRAN>(pkg->repository)) {
+            stream << "I" << " cran " << pkg->name << '\n';
+        } else {
+            LOG(WARN) << "Unknown R package repository type for package "
+                      << pkg->name;
         }
     }
 

--- a/src/manifest_section.h
+++ b/src/manifest_section.h
@@ -205,42 +205,9 @@ inline bool RPackagesManifestSection::save(std::ostream& stream,
         sorted_packages.emplace_back(p);
     }
 
-    // TODO: rather add a operator< for RPackage (using std::tie)
-    std::sort(
-        sorted_packages.begin(), sorted_packages.end(),
-        [](RPackage const* lhs, RPackage const* rhs) {
-            std::string left;
-            std::string right;
-            if (std::holds_alternative<RPackage::GitHub>(lhs->repository)) {
-                left = std::get<RPackage::GitHub>(lhs->repository).org + '/' +
-                       std::get<RPackage::GitHub>(lhs->repository).name + '@' +
-                       std::get<RPackage::GitHub>(lhs->repository).ref;
-            } else if (std::holds_alternative<RPackage::CRAN>(
-                           lhs->repository)) {
-                left = lhs->name;
-            } else {
-                LOG(WARN) << "Unknown R package repository type for package "
-                          << lhs->name;
-                return false; // do not sort unknown types
-            }
+    std::sort(sorted_packages.begin(), sorted_packages.end());
 
-            if (std::holds_alternative<RPackage::GitHub>(rhs->repository)) {
-                right = std::get<RPackage::GitHub>(rhs->repository).org + '/' +
-                        std::get<RPackage::GitHub>(rhs->repository).name + '@' +
-                        std::get<RPackage::GitHub>(rhs->repository).ref;
-            } else if (std::holds_alternative<RPackage::CRAN>(
-                           rhs->repository)) {
-                right = rhs->name;
-            } else {
-                LOG(WARN) << "Unknown R package repository type for package "
-                          << rhs->name;
-                return false; // do not sort unknown types
-            }
-
-            return left < right;
-        });
-
-    for (auto const* pkg : manifest.r_packages) {
+    for (auto const* pkg : sorted_packages) {
         if (std::holds_alternative<RPackage::GitHub>(pkg->repository)) {
             auto const& gh = std::get<RPackage::GitHub>(pkg->repository);
             stream << "github " << gh.org << '/' << gh.name << '@' << gh.ref

--- a/src/r4r_lib.cpp
+++ b/src/r4r_lib.cpp
@@ -1,44 +1,41 @@
 #include "../include/r4r/r4r_lib.h"
 #include "main_common.h"
 
-static bool isEmptyOrWhitespace(const std::string& str) {
-    return str.empty() || std::all_of(str.begin(), str.end(), [](unsigned char c) {
-        return std::isspace(c);
-    });
+static bool isEmptyOrWhitespace(std::string const& str) {
+    return str.empty() ||
+           std::all_of(str.begin(), str.end(),
+                       [](unsigned char c) { return std::isspace(c); });
 }
 
-int r4r_trace_expression(std::string expression, std::string output, std::string imageTag, std::string containerName, std::string baseImage, bool skipManifest ) {
+int r4r_trace_expression(std::string expression, std::string output,
+                         std::string imageTag, std::string containerName,
+                         std::string baseImage, bool skipManifest) {
     Options options;
     options.os_release = parse_os();
     options.docker_base_image = base_image(options.os_release);
-    
 
-    if (!isEmptyOrWhitespace(baseImage))
-        options.docker_base_image =  baseImage;
- 
-    
+    if (!isEmptyOrWhitespace(baseImage)) {
+        options.docker_base_image = baseImage;
+    }
+
     //-vvv (verbose)
     --options.log_level;
     --options.log_level;
     //--options.log_level;
 
     options.output_dir = output;
-    options.skip_manifest = skipManifest; 
+    options.skip_manifest = skipManifest;
 
- 
     options.default_image_file = get_user_cache_dir() / kBinaryName /
-                                (options.docker_base_image + ".cache");
+                                 (options.docker_base_image + ".cache");
 
-                                
     options.docker_image_tag = imageTag;
     options.docker_container_name = containerName;
 
-   
     options.cmd.push_back("R");
     options.cmd.push_back("-e");
     options.cmd.push_back(expression);
 
- 
     try {
         return run_from_options(options);
     } catch (std::exception const& e) {
@@ -48,5 +45,4 @@ int r4r_trace_expression(std::string expression, std::string output, std::string
         std::cerr << "Unhandled unknown exception." << '\n';
         return EXIT_FAILURE;
     }
-
 }

--- a/src/resolvers.h
+++ b/src/resolvers.h
@@ -49,14 +49,15 @@ inline void DebPackageResolver::resolve(Files& files, Symlinks& symlinks,
             if (auto const* pkg = dpkg_database_->lookup_by_path(p); pkg) {
                 if (pkg->name.find("rstudio") != std::string::npos ||
                     pkg->name.find("bslib") != std::string::npos) {
-                    //  TODO: GET RID OF THIS!! THIS IS A HACK TO MAKE TRACING PASS FROM RSTUDIO   
+                    //  TODO: GET RID OF THIS!! THIS IS A HACK TO MAKE TRACING
+                    //  PASS FROM RSTUDIO
                     continue;
                 }
-                
+
                 LOG(DEBUG) << "Resolved: " << path << " to: " << pkg->name;
 
                 // TODO: check that the file size is the same
-                
+
                 resolved_packages.insert(pkg);
                 resolved_files++;
                 return true;

--- a/src/rpkg_database.h
+++ b/src/rpkg_database.h
@@ -28,6 +28,10 @@ struct RPackage {
             return std::tie(org, name, ref) ==
                    std::tie(other.org, other.name, other.ref);
         };
+        bool operator<(GitHub const& other) const {
+            return std::tie(org, name, ref) <
+                   std::tie(other.org, other.name, other.ref);
+        }
         friend std::ostream& operator<<(std::ostream& os, GitHub const& gh) {
             return os << "GitHub(" << gh.org << "/" << gh.name << "@" << gh.ref
                       << ")";
@@ -36,7 +40,7 @@ struct RPackage {
 
     struct CRAN {
         bool operator==(const CRAN&) const = default;
-
+        bool operator<(const CRAN&) const = default;
         friend std::ostream& operator<<(std::ostream& os,
                                         [[maybe_unused]] CRAN const& cran) {
             return os << "CRAN";
@@ -45,7 +49,7 @@ struct RPackage {
 
     using Repository = std::variant<GitHub, CRAN>;
 
-    // TODO: change the order name, followd by version
+    // TODO: change the order name, followed by version
     std::string name;
     fs::path lib_path;
     std::string version;
@@ -60,6 +64,30 @@ struct RPackage {
                std::tie(other.name, other.lib_path, other.version,
                         other.dependencies, other.is_base,
                         other.needs_compilation, repository);
+    }
+
+    bool operator<(RPackage const& other) const {
+        // Determine if repositories are of CRAN or GitHub type
+        bool this_is_cran = std::holds_alternative<CRAN>(repository);
+        bool other_is_cran = std::holds_alternative<CRAN>(other.repository);
+
+        // If one is CRAN and the other is GitHub, CRAN comes first
+        if (this_is_cran != other_is_cran) {
+            return this_is_cran; // CRAN is considered less than GitHub
+        }
+
+        // If both are CRAN or both are GitHub, proceed with detailed comparison
+        if (this_is_cran && other_is_cran) {
+            return name < other.name;
+        } else { // Both are GitHub
+            auto const& this_gh = std::get<GitHub>(repository);
+            auto const& other_gh = std::get<GitHub>(other.repository);
+            std::string left =
+                this_gh.org + '/' + this_gh.name + '@' + this_gh.ref;
+            std::string right =
+                other_gh.org + '/' + other_gh.name + '@' + other_gh.ref;
+            return left < right;
+        }
     }
 };
 

--- a/src/syscall_monitor.h
+++ b/src/syscall_monitor.h
@@ -393,7 +393,8 @@ SyscallMonitor::spawn_process(std::vector<std::string> const& cmd) {
         auto const& program = cmd.front();
         execvp(program.c_str(), c_args.data());
 
-        std::cerr << "execvp: " << strerror(errno) << " (" << errno << ")\n";
+        std::cerr << "execvp: " << strerror(errno) << " (" << errno << ") for"
+                  << program << "\n";
 
         return kSpawnErrorExitCode;
     };

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -1023,7 +1023,6 @@ class Tracer {
                                          std::string const& docker_base_image,
                                          IgnoreFileMap& map) {
         auto default_files = [&]() {
-
             if (fs::exists(default_image_file)) {
                 return DefaultImageFiles::from_file(default_image_file);
             }

--- a/tests/file_tracer_test.cpp
+++ b/tests/file_tracer_test.cpp
@@ -199,7 +199,7 @@ TEST(FileTracerTest, NewFstatAtSyscall) {
 
     SyscallMonitor monitor(
         [&test_file]() {
-            struct stat statbuf{};
+            struct stat statbuf {};
 
             int ret = syscall(SYS_newfstatat, AT_FDCWD, test_file->c_str(),
                               &statbuf, 0); // NOLINT(*-pro-type-vararg)

--- a/tests/filesystem_trie_test.cpp
+++ b/tests/filesystem_trie_test.cpp
@@ -1,7 +1,7 @@
 #include "filesystem_trie.h"
+#include <algorithm>
 #include <gtest/gtest.h>
 #include <vector>
-#include <algorithm>
 
 #include <algorithm>
 
@@ -150,10 +150,11 @@ TEST(FileSystemTrieIteratorTest, IteratorVisitsAllNodes) {
 
     std::vector<std::pair<fs::path, int>> actual;
     auto exists = [&](auto const& elem) {
-       // auto it = std::find(actual.begin(), actual.end(), elem);
-        auto it = std::find_if(actual.begin(), actual.end(), [&](const auto& pair) {
-            return pair.first == elem.first && pair.second == elem.second;
-        });
+        // auto it = std::find(actual.begin(), actual.end(), elem);
+        auto it =
+            std::find_if(actual.begin(), actual.end(), [&](auto const& pair) {
+                return pair.first == elem.first && pair.second == elem.second;
+            });
         return it != actual.end();
     };
     for (auto const& node : trie) {

--- a/tests/manifest_package_section_test.cpp
+++ b/tests/manifest_package_section_test.cpp
@@ -27,6 +27,6 @@ TEST_F(RPackageManifestSectionTest, SaveValidEntries) {
     EXPECT_TRUE(hasContent);
 
     auto lines = string_split(oss.str(), '\n');
-    EXPECT_EQ(lines[lines.size() - 2], "I github org/name@ref");
-    EXPECT_EQ(lines[lines.size() - 1], "I cran testpkg");
+    EXPECT_EQ(lines[lines.size() - 2], "github org/name@ref");
+    EXPECT_EQ(lines[lines.size() - 1], "cran testpkg 1.0");
 }

--- a/tests/manifest_package_section_test.cpp
+++ b/tests/manifest_package_section_test.cpp
@@ -1,0 +1,32 @@
+#include "manifest_section.h"
+#include <gtest/gtest.h>
+#include <sstream>
+#include <string>
+
+class RPackageManifestSectionTest : public ::testing::Test {
+  protected:
+    RPackagesManifestSection section_;
+    Manifest manifest_;
+};
+
+TEST_F(RPackageManifestSectionTest, SaveValidEntries) {
+    manifest_.r_packages.insert(new RPackage{"testpkg",
+                                             "/path/to/lib",
+                                             "1.0",
+                                             {"dep1", "dep2"},
+                                             false,
+                                             false,
+                                             RPackage::CRAN{}});
+    manifest_.r_packages.insert(
+        new RPackage("", "/path/result", "1.0", {}, false, true,
+                     RPackage::GitHub{"org", "name", "ref"}));
+
+    std::ostringstream oss;
+    bool hasContent = section_.save(oss, manifest_);
+
+    EXPECT_TRUE(hasContent);
+
+    auto lines = string_split(oss.str(), '\n');
+    EXPECT_EQ(lines[lines.size() - 2], "I github org/name@ref");
+    EXPECT_EQ(lines[lines.size() - 1], "I cran testpkg");
+}

--- a/tests/manifest_package_section_test.cpp
+++ b/tests/manifest_package_section_test.cpp
@@ -27,6 +27,7 @@ TEST_F(RPackageManifestSectionTest, SaveValidEntries) {
     EXPECT_TRUE(hasContent);
 
     auto lines = string_split(oss.str(), '\n');
-    EXPECT_EQ(lines[lines.size() - 2], "github org/name@ref");
-    EXPECT_EQ(lines[lines.size() - 1], "cran testpkg 1.0");
+    // cran packages are listed before github packages
+    EXPECT_EQ(lines[lines.size() - 2], "cran testpkg 1.0");
+    EXPECT_EQ(lines[lines.size() - 1], "github org/name@ref");
 }


### PR DESCRIPTION
Currently, the manifest class holds all necessary information, but the manifest file only show the files.

- [ ] add R packages
- [ ] add deb packages
- [ ] add environment variables
- [ ] regenerate the manifest if necessary and show it again to the user

## R packages

I suggest the following format:

```
 r-packages:
  cran package_name version
  github org/name@ref
  # ignored package
```


That is not enough information to reconstruct all we know about a R package (e.g. NeedsCompilation, the dependencies and so on) so the idea would be to filter out package that are commented or removed, because we also maintain all the necessary information in memory and we never build from the manifest from scratch. 

## Deb packages

```
deb-packages:
  package_name
  # package
```

Similar as for the R packages.

## Environment variables

```
env:
  Name value
```

